### PR TITLE
Stop grasp in the beginning of pick-object

### DIFF
--- a/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
+++ b/jsk_arc2017_baxter/euslisp/lib/arc-interface.l
@@ -267,6 +267,8 @@
   (:pick-object-with-movable-region
     (arm movable-region &key (n-trial 1) (n-trial-same-pos 1)
          (do-stop-grasp nil) (grasp-style :suction))
+    (send *ri* :stop-grasp arm)
+    (send self :move-fingers-pinch->init arm)
     (send *ri* :calib-proximity-threshold arm)
     (let (graspingp avs object-index obj-pos obj-cube pinch-yaw)
       ;; TODO: object-index is set randomly


### PR DESCRIPTION
After `pick-object` state, suction/pinch grasping is continued.
So we need to stop grasping in the beginning of `pick-object` if we want to loop `pick-object`.


Currently, I stop grasping in `recognize-object` like https://github.com/start-jsk/jsk_apc/blob/master/jsk_arc2017_baxter/euslisp/lib/pick-interface.l#L87-L88.
Or in `return-from-pick-object` like https://github.com/start-jsk/jsk_apc/blob/master/jsk_arc2017_baxter/euslisp/lib/pick-interface.l#L137 and https://github.com/start-jsk/jsk_apc/blob/master/jsk_arc2017_baxter/euslisp/lib/pick-interface.l#L144